### PR TITLE
Replace soft-deprecated `funs()` with `list()`

### DIFF
--- a/R/basketball_insider_functions.R
+++ b/R/basketball_insider_functions.R
@@ -278,7 +278,7 @@ nba_team_salaries <-
 
     salary_data <-
       salary_data %>%  mutate_if(is.character,
-                                 funs(. %>% str_replace_all("\\\\", "") %>% str_trim()))
+                                 list(. %>% str_replace_all("\\\\", "") %>% str_trim()))
 
 
     year_1_salary <-

--- a/R/bref.R
+++ b/R/bref.R
@@ -1202,7 +1202,7 @@ all_nba_teams <-
       mutate_at(df %>% dplyr::select(-one_of(c(
         "Tm", "Player", "Pos"
       ))) %>% names(),
-      funs(. %>% as.numeric())) %>%
+      list(. %>% as.numeric())) %>%
       filter(!Rk %>% is.na()) %>%
       suppressWarnings() %>%
       dplyr::select(-dplyr::matches("Rk"))
@@ -1259,7 +1259,7 @@ all_nba_teams <-
     df <-
       df %>%
       mutate_at(df %>% dplyr::select(dplyr::matches("pct")) %>% names(),
-                funs(ifelse(. >= 1, . / 100, .))) %>%
+                list(ifelse(. >= 1, . / 100, .))) %>%
       mutate(typeData = name_slug) %>%
       dplyr::select(typeData, everything())
 
@@ -1434,7 +1434,7 @@ bref_players_stats <-
       mutate_all(str_trim) %>%
       mutate(rankConference = rankConference %>% str_replace_all('\\)', "")) %>%
       mutate_at(c("rankConference", "winsTeam", "lossesTeam"),
-                funs(. %>% as.integer())) %>%
+                list(. %>% as.integer())) %>%
       mutate_at(
         c(
           "pctWins",
@@ -1443,7 +1443,7 @@ bref_players_stats <-
           "ptsOppPerGame",
           "ratingStrengthOfSchedule"
         ),
-        funs(. %>% as.character() %>% readr::parse_number() %>% as.numeric())
+        list(. %>% as.character() %>% readr::parse_number() %>% as.numeric())
       ) %>%
       mutate(
         gamesBehind1Conference = ifelse(
@@ -1497,7 +1497,7 @@ bref_players_stats <-
       mutate_all(str_trim) %>%
       mutate(rankConference = rankConference %>% str_replace_all('\\)', "")) %>%
       mutate_at(c("rankConference", "winsTeam", "lossesTeam"),
-                funs(. %>% as.integer())) %>%
+                list(. %>% as.integer())) %>%
       mutate(idRow = 1:n()) %>%
       left_join(df_divisions) %>%
       filter(!rankConference %>% is.na()) %>%
@@ -1512,7 +1512,7 @@ bref_players_stats <-
           "ptsOppPerGame",
           "ratingStrengthOfSchedule"
         ),
-        funs(. %>% as.character() %>% readr::parse_number() %>% as.numeric())
+        list(. %>% as.character() %>% readr::parse_number() %>% as.numeric())
       ) %>%
       mutate(
         gamesBehind1Division = ifelse(gamesBehind1Division %>% is.na(), 0, gamesBehind1Division),
@@ -1694,7 +1694,7 @@ bref_players_stats <-
         nameTeam = nameTeam %>% str_replace_all("\\*", "")
       ) %>%
       mutate_at(numeric_names,
-                funs(. %>% as.character() %>% readr::parse_number())) %>%
+                list(. %>% as.character() %>% readr::parse_number())) %>%
       dplyr::select(nameTeam, isPlayoffTeam, everything()) %>%
       suppressWarnings()
 
@@ -1751,7 +1751,7 @@ bref_players_stats <-
         nameTeam = nameTeam %>% str_replace_all("\\*", "")
       ) %>%
       mutate_at(numeric_names,
-                funs(. %>% as.character() %>% readr::parse_number())) %>%
+                list(. %>% as.character() %>% readr::parse_number())) %>%
       dplyr::select(nameTeam, isPlayoffTeam, everything()) %>%
       suppressWarnings()
 
@@ -2272,7 +2272,7 @@ all_star_games <-
     all_star_data <-
       all_star_data %>%
       mutate_if(is.character,
-                funs(. %>% str_trim()))
+                list(. %>% str_trim()))
 
     all_star_data
   }
@@ -2317,7 +2317,7 @@ bref_injuries <-
       tidyr::separate(descriptionInjury, into = c("statusTypeInjury", "descriptionInjury"), sep = "\\ - ") %>%
       separate(statusTypeInjury, into = c("statusGame", "typeInjury"), sep = "\\(") %>%
       mutate(typeInjury = typeInjury %>% str_remove_all("\\)")) %>%
-      mutate_if(is.character, funs(. %>% str_trim())) %>%
+      mutate_if(is.character, list(. %>% str_trim())) %>%
       mutate(isOut = statusGame %>% str_to_lower() %>% str_detect("out"))
 
     data
@@ -2483,14 +2483,14 @@ dictionary_bref_awards <-
           nameExecutive = nameExecutive %>% gsub("\\(Tie)", "", .) %>% str_trim()
         ) %>%
         mutate_if(is.character,
-                  funs(str_trim))
+                  list(str_trim))
     }
 
   if (data %>% tibble::has_name("agePlayer")) {
     data <-
       data %>%
       mutate_at("agePlayer",
-                funs(. %>% as.numeric()))
+                list(. %>% as.numeric()))
 
   }
     if (data %>% tibble::has_name("namePlayer")) {
@@ -2501,7 +2501,7 @@ dictionary_bref_awards <-
           namePlayer = namePlayer %>% gsub("\\(Tie)", "", .) %>% str_trim()
         ) %>%
         mutate_if(is.character,
-                  funs(str_trim))
+                  list(str_trim))
 
       data <-
         data %>%
@@ -2714,7 +2714,7 @@ bref_awards <-
           df %>%
           spread(nameItem, value) %>%
           mutate_at(c("agePlayer", "pctVote", "pointsVote", "votesFirst"),
-                    funs(as.numeric)) %>%
+                    list(as.numeric)) %>%
           select(slugTable, idRow:namePlayer, slugTeam, pctVote, votesFirst, everything())
 
         df

--- a/R/bref_bio.R
+++ b/R/bref_bio.R
@@ -357,7 +357,7 @@
           sep = "\\ "
         ) %>%
         mutate_at(c("yearHighSchool", "rankHighSchool"),
-                  funs(. %>% as.character() %>% readr::parse_number()))
+                  list(. %>% as.character() %>% readr::parse_number()))
 
     }
 

--- a/R/draft_combine.R
+++ b/R/draft_combine.R
@@ -96,7 +96,7 @@
     data <-
       data %>%
       mutate_at(num_names,
-                funs(. %>% as.character() %>% readr::parse_number())) %>%
+                list(. %>% as.character() %>% readr::parse_number())) %>%
       dplyr::rename(slugPosition = groupPosition)
 
     if (actual_names[actual_names %>% str_detect("set")] %>% length() > 0) {

--- a/R/game_logs.R
+++ b/R/game_logs.R
@@ -124,7 +124,7 @@
         ) %>%
         ungroup() %>%
         mutate_if(is.logical,
-                  funs(ifelse(. %>% is.na(), FALSE, .)))
+                  list(ifelse(. %>% is.na(), FALSE, .)))
 
       data <-
         data %>%
@@ -194,7 +194,7 @@
         ) %>%
         ungroup() %>%
         mutate_if(is.logical,
-                  funs(ifelse(. %>% is.na(), FALSE, .)))
+                  list(ifelse(. %>% is.na(), FALSE, .)))
 
       data <-
         data %>%

--- a/R/hoops_hype_functions.R
+++ b/R/hoops_hype_functions.R
@@ -182,7 +182,7 @@ hoops_hype_salary_summary <-
     salary_table_df <-
       salary_table_df %>%
       mutate_at(salary_table_df %>% select(dplyr::matches("X")) %>% names(),
-                funs(. %>%  as.character() %>% readr::parse_number()))
+                list(. %>%  as.character() %>% readr::parse_number()))
 
     salary_data <-
       salary_table_df %>%

--- a/R/nba_rankings.R
+++ b/R/nba_rankings.R
@@ -37,7 +37,7 @@
       var_df <-
         var_data %>%
         flatten_df() %>%
-        mutate_all(funs(. %>% as.character() %>% readr::parse_number())) %>%
+        mutate_all(list(. %>% as.character() %>% readr::parse_number())) %>%
         purrr::set_names(var_names) %>%
         mutate(idTeam = teams) %>%
         suppressWarnings()

--- a/R/new_ish.R
+++ b/R/new_ish.R
@@ -1299,7 +1299,7 @@ munge_nba_data <- function(data) {
       data %>%
       tidyr::separate(timeGame, into = c("hours", "minutes"), sep = "\\:") %>%
       mutate_at(c("hours", "minutes"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       mutate(lengthGameMinutes = (hours * 60) + minutes) %>%
       dplyr::select(-one_of(c("hours", "minutes")))
   }
@@ -1309,7 +1309,7 @@ munge_nba_data <- function(data) {
       data <- data %>%
         tidyr::separate(minutes, into = c("min", "seconds"), sep = "\\:") %>%
         mutate_at(c("min", "seconds"),
-                  funs(. %>% as.numeric())) %>%
+                  list(. %>% as.numeric())) %>%
         mutate(seconds = seconds / 60,
                minExact = min + seconds) %>%
         dplyr::select(-c(min, seconds)) %>%
@@ -1326,7 +1326,7 @@ munge_nba_data <- function(data) {
   data <-
     data %>%
     mutate_at(num_names,
-              funs(. %>% as.numeric())) %>%
+              list(. %>% as.numeric())) %>%
     suppressWarnings()
 
   if (data %>% tibble::has_name("fga") && data %>%  tibble::has_name("fg3a")) {
@@ -1352,7 +1352,7 @@ munge_nba_data <- function(data) {
       ) %>%
       dplyr::select(-remove) %>%
       mutate_if(is.character,
-                funs(. %>% str_trim())) %>%
+                list(. %>% str_trim())) %>%
       dplyr::select(slugSeason:outcomeGame, locationGame, everything())
   }
 
@@ -1387,7 +1387,7 @@ munge_nba_data <- function(data) {
       data %>%
       tidyr::separate(slugScore, into = c("scoreHome", "scoreAway"), sep = "\\ - ", remove = F) %>%
       mutate_at(c("scoreHome", "scoreAway"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       mutate(slugTeamLeading = case_when(marginScore == 0 ~ "Tie",
                                          marginScore < 0 ~ "Away",
                                          TRUE ~ "Home"))
@@ -1410,7 +1410,7 @@ munge_nba_data <- function(data) {
         remove = F
       ) %>%
       mutate_at(c("minuteRemainingQuarter", "secondsRemainingQuarter"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
 
       mutate(
         minuteGame = ((numberPeriod - 1) * 12) + (12 - minuteRemainingQuarter) + (((
@@ -1436,7 +1436,7 @@ munge_nba_data <- function(data) {
                       into = c("winsTeam", "lossesTeam"),
                       remove = F) %>%
       mutate_at(c("winsTeam", "lossesTeam"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       mutate(countGamesTeam = winsTeam + lossesTeam,
              pctWinTeam = winsTeam / (countGamesTeam)) %>%
       dplyr::select(idGame, slugRecordTeam,countGamesTeam, pctWinTeam, everything())
@@ -1444,9 +1444,9 @@ munge_nba_data <- function(data) {
   data <-
     data %>%
     mutate_if(is.character,
-              funs(str_trim)) %>%
+              list(str_trim)) %>%
     mutate_if(is.character,
-              funs(ifelse(. == "", NA, .)))
+              list(ifelse(. == "", NA, .)))
 
   logicial_names <-
     data %>% dplyr::select(dplyr::matches("^has[A-Z]|^is[A-Z]")) %>% names()
@@ -1455,7 +1455,7 @@ munge_nba_data <- function(data) {
     data <-
       data %>%
       mutate_at(logicial_names,
-                funs(. %>% as.numeric() %>% as.logical()))
+                list(. %>% as.numeric() %>% as.logical()))
   }
 
   id_names <-
@@ -1465,7 +1465,7 @@ munge_nba_data <- function(data) {
     data <-
       data %>%
       mutate_at(id_names,
-                funs(. %>% as.numeric()))
+                list(. %>% as.numeric()))
   }
 
   if (data %>% has_name("teamName") & !data %>% has_name("cityTeam")) {
@@ -1556,7 +1556,7 @@ munge_nba_data <- function(data) {
     data %>%
     mutate_at(
       .vars = data %>% select(dplyr::matches("^pts|^blk")) %>% names(),
-      funs(. %>% as.numeric())
+      list(. %>% as.numeric())
     )
 
   data <-
@@ -1579,7 +1579,7 @@ munge_nba_data <- function(data) {
   data <-
     data %>%
     mutate_if(is.numeric,
-              funs(ifelse(. %>% is.nan(), 0 , .)))
+              list(ifelse(. %>% is.nan(), 0 , .)))
 
   data
 }

--- a/R/new_stats.R
+++ b/R/new_stats.R
@@ -390,7 +390,7 @@ current_schedule <-
   df_descriptions <-
     data_frame(descriptionGame = json_data$nugget$text) %>%
     mutate(idRow = 1:n()) %>%
-    mutate_all(funs(ifelse(. == "", NA, .)))
+    mutate_all(list(ifelse(. == "", NA, .)))
 
   df_home <-
     json_data$hTeam %>% flatten() %>% dplyr::as_data_frame() %>%
@@ -453,7 +453,7 @@ coaching_staffs <-
                          "idTeam", "numberSort",
                          "nameCollegeCoach")) %>%
       mutate_at(c("idCoach", "numberSort", "idTeam"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       select(-numberSort)
 
     data <-
@@ -537,7 +537,7 @@ nbastats_api_parameters <-
           "yearSeasonLast",
           "yearSeasonFirst"
         ),
-        funs(. %>% as.integer())
+        list(. %>% as.integer())
       ) %>%
       mutate(
         isActive = as.logical(isActive),
@@ -609,7 +609,7 @@ parse_for_seasons_data <-
     seasons %>%
       mutate_all(as.character) %>%
       mutate_at(c( "yearDataEnd", "idLeagueSeasonType", "yearDataStart"),
-                funs(. %>% as.numeric()))
+                list(. %>% as.numeric()))
   }
 
 .parse_for_teams <-
@@ -645,10 +645,10 @@ parse_for_seasons_data <-
                          "colorsTeam")) %>%
       mutate_at(c("idTeam",
                 "idConference", "idDivision", "isNonNBATeam", "yearPlayedLast", "idLeague"),
-                funs(. %>% as.integer())) %>%
+                list(. %>% as.integer())) %>%
       mutate(nameTeam = str_c(cityTeam, teamNameFull, sep = " ")) %>%
       mutate_if(is.character,
-                funs(ifelse(. == "", NA, .))) %>%
+                list(ifelse(. == "", NA, .))) %>%
       dplyr::select(nameTeam, everything())
 
     df_teams <-
@@ -815,10 +815,10 @@ nba_players <-
           "yearSeasonLast",
           "yearSeasonFirst"
         ),
-        funs(. %>% as.integer())
+        list(. %>% as.integer())
       ) %>%
       mutate_if(is.character,
-                funs(ifelse(. == "", NA, .))) %>%
+                list(ifelse(. == "", NA, .))) %>%
       mutate(
         isActive = as.logical(isActive),
         countSeasons = (yearSeasonLast - yearSeasonFirst)

--- a/R/play_by_play.R
+++ b/R/play_by_play.R
@@ -125,7 +125,7 @@
       purrr::set_names(names_md) %>%
       mutate(dateGame = dateGame %>% lubridate::mdy()) %>%
       mutate_at(c("idGame", "idTeamHome", "idTeamAway", "ptsTotalTeamHome", "ptsTotalTeamAway"),
-                funs(. %>% as.integer())
+                list(. %>% as.integer())
       ) %>%
       select(-dplyr::matches("pts"))
 

--- a/R/player_profile.R
+++ b/R/player_profile.R
@@ -47,7 +47,7 @@
     data <-
       data %>%
       mutate_at(c("idPlayer", "numberTeamAward", "idTeam"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       suppressWarnings() %>%
       mutate(
         dateMonthAward = lubridate::mdy(dateMonthAward),
@@ -186,7 +186,7 @@ players_awards <-
                       sep = "\\, ") %>%
       tidyr::unite(namePlayer, nameFirst, nameLast, sep = " ") %>%
       mutate_if(is.character,
-                funs(ifelse(. == "", NA_character_, .))) %>%
+                list(ifelse(. == "", NA_character_, .))) %>%
       remove_na_columns() %>%
       dplyr::select(idPlayer, namePlayer, everything())
 

--- a/R/players.R
+++ b/R/players.R
@@ -22,7 +22,7 @@
       df_parameters <-
         df_parameters %>%
         mutate_at(df_parameters %>% dplyr::select(dplyr::matches("is[A-Z]")) %>% names(),
-                  funs(ifelse(. == "Y", 1, 0) %>% as.logical())) %>%
+                  list(ifelse(. == "Y", 1, 0) %>% as.logical())) %>%
         mutate(numberTable = x,) %>%
         select(one_of(c("numberTable", "typeMeasure", "modeSearch")), everything()) %>%
         suppressWarnings()

--- a/R/players_teams.R
+++ b/R/players_teams.R
@@ -679,7 +679,7 @@
           df_parameters %>%
           mutate_at(
             df_parameters %>% dplyr::select(dplyr::matches("is[A-Z]")) %>% names(),
-            funs(ifelse(. == "Y", 1, 0) %>% as.logical())
+            list(ifelse(. == "Y", 1, 0) %>% as.logical())
           ) %>%
           mutate(numberTable = table_id) %>%
           select(numberTable, everything())

--- a/R/pst.R
+++ b/R/pst.R
@@ -42,7 +42,7 @@
         isDTD = descriptionTransaction %>% str_detect("DTD")
       ) %>%
       mutate_if(is.character,
-                funs(str_trim)) %>%
+                list(str_trim)) %>%
       suppressWarnings()
 
     data <-

--- a/R/random.R
+++ b/R/random.R
@@ -25,13 +25,13 @@
       purrr::set_names(actual_names) %>%
       tidyr::unite(namePlayer, nameFirst, nameLast, sep = " ") %>%
       mutate_at(c("idUpdate", "idPlayer", "idRotoWorld", "dateISO", "numberPriority"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       mutate_at(c("datetimePublished", "datetimeUpdatedLast"),
-                funs(. %>% lubridate::mdy_hms())) %>%
+                list(. %>% lubridate::mdy_hms())) %>%
       mutate(isInjured = !slugInjured %>% str_detect("NO")) %>%
       dplyr::select(idPlayer, namePlayer, slugTeam, codeTeam, datetimePublished, articleHeadline, everything()) %>%
       mutate_if(is.character,
-                funs(ifelse(. == "", NA_character_, .)))
+                list(ifelse(. == "", NA_character_, .)))
 
     if (return_message) {
       glue::glue("Acquired {nrow(data)} Roto Wire articles for {data$namePlayer %>% unique()}") %>% cat(fill = T)
@@ -202,7 +202,7 @@ players_rotowire <-
       purrr::set_names(c("title", "descriptionTransaction", "idTeam", "nameTeamFrom",
                          "idPlayer", "dateTransaction", "idTransaction", "meta")) %>%
       mutate_at(c("idPlayer", "idTransaction", "idTeam"),
-                funs(. %>% as.numeric())) %>%
+                list(. %>% as.numeric())) %>%
       mutate(dateTransaction = lubridate::mdy(dateTransaction)) %>%
       select(-one_of("title", "nameTeamFrom", "meta")) %>%
       suppressWarnings()

--- a/R/seasons_rosters.R
+++ b/R/seasons_rosters.R
@@ -143,7 +143,7 @@
                         sep = "\\-",
                         into = c("feet", "inches")) %>%
         mutate_at(c("feet", "inches"),
-                  funs(. %>% as.numeric())) %>%
+                  list(. %>% as.numeric())) %>%
         mutate(heightInches = (12 * feet) + inches) %>%
         select(-one_of(c("feet", "inches"))) %>%
         select(slugSeason, idTeam:weightLBS, heightInches, everything())

--- a/R/standings.R
+++ b/R/standings.R
@@ -96,7 +96,7 @@ current_standings <-
       dplyr::select(-dplyr::matches("Remove")) %>%
       munge_nba_data() %>%
       mutate_at(c("pctLosses", "pctWins"),
-                funs(. / 100)) %>%
+                list(. / 100)) %>%
       left_join(df_dict_nba_teams %>% select(idTeam, slugTeam, nameTeam, dplyr::matches("url"))) %>%
       mutate(dateData = Sys.Date(),
              rankTeam = 1:n()) %>%

--- a/R/summer_league.R
+++ b/R/summer_league.R
@@ -45,7 +45,7 @@ sl_players <-
 
         if (df %>% tibble::has_name("dateBirth")) {
           df <- df %>% mutate_at('dateBirth',
-                                 funs(lubridate::ymd))
+                                 list(lubridate::ymd))
         }
         if (height_cols %>% length() > 0) {
           height_change <- height_cols[height_cols %in% names(df)]
@@ -53,7 +53,7 @@ sl_players <-
           df <-
             df %>%
             mutate_at(height_change,
-                      funs(. %>% as.numeric()))  %>%
+                      list(. %>% as.numeric()))  %>%
             mutate(heightPlayer = (12 * heightFeet) + heightInches) %>%
             suppressWarnings()
         }
@@ -154,7 +154,7 @@ sl_teams <-
           data %>%
           munge_nba_data() %>%
           mutate_if(is.character,
-                    funs(ifelse(. == "", NA_character_, .)))
+                    list(ifelse(. == "", NA_character_, .)))
 
         if (assign_to_environment) {
           league_slug <- case_when(league == "standard" ~ "",

--- a/R/synergy.R
+++ b/R/synergy.R
@@ -57,7 +57,7 @@
     pct_cols <- data %>% select(dplyr::matches("pct[A-Z]")) %>% names()
     data %>%
       mutate_at(pct_cols,
-                funs(. %>% as.numeric() /  100))
+                list(. %>% as.numeric() /  100))
   }
 
 .dictionary_synergy_categories <-
@@ -172,7 +172,7 @@
         everything()
       ) %>%
       mutate_at("idTeam",
-                funs(. %>% as.numeric()))
+                list(. %>% as.numeric()))
 
     if (result_type %>% str_to_lower() == "player") {
       data <-
@@ -192,14 +192,14 @@
   data <-
     data %>%
     mutate_at(num_cols,
-             funs(. %>% as.character() %>% readr::parse_number()))
+             list(. %>% as.character() %>% readr::parse_number()))
 
   ppp_names <- data %>% dplyr::select(dplyr::matches("PPP")) %>% names()
 
   if (ppp_names %>% length() >0) {
     data <- data %>%
       mutate_at(ppp_names,
-                funs(. %>% as.numeric()))
+                list(. %>% as.numeric()))
   }
 
   data <-

--- a/R/team.R
+++ b/R/team.R
@@ -37,7 +37,7 @@
         df_parameters %>%
         mutate_at(
           df_parameters %>% dplyr::select(dplyr::matches("is[A-Z]")) %>% names(),
-          funs(ifelse(. == "Y", 1, 0) %>% as.logical())
+          list(ifelse(. == "Y", 1, 0) %>% as.logical())
         ) %>%
         mutate(numberTable = x) %>%
         select(numberTable, everything())
@@ -933,10 +933,10 @@ teams_tables <-
       remove_zero_sum_cols() %>%
       select(-one_of(c("numberTable", "idLeague"))) %>%
       mutate_if(is.character,
-                funs(ifelse(. == "", NA, .))) %>%
+                list(ifelse(. == "", NA, .))) %>%
       remove_na_columns() %>%
       mutate_at(c("locationX", "locationY"),
-                funs(. %>% as.character() %>% readr::parse_number())) %>%
+                list(. %>% as.character() %>% readr::parse_number())) %>%
       suppressWarnings() %>%
       suppressMessages() %>%
       select(dplyr::matches("yearSeason", "slugSeason", "nameTeam"), everything()) %>%

--- a/R/team_tables.R
+++ b/R/team_tables.R
@@ -256,7 +256,7 @@ teams_details <-
   data <-
     data %>%
     mutate_at(num_cols,
-              funs(. %>% as.numeric())) %>%
+              list(. %>% as.numeric())) %>%
     mutate(modeSearch = mode) %>%
     dplyr::select(modeSearch, everything())
 

--- a/R/teams_rosters_history.R
+++ b/R/teams_rosters_history.R
@@ -221,7 +221,7 @@ team_season_roster <-
           "countSeasons",
           "idPlayer"
         ),
-        funs(. %>% as.character() %>% readr::parse_number())
+        list(. %>% as.character() %>% readr::parse_number())
       ) %>%
       mutate(
         dateBirth = lubridate::mdy(dateBirth),
@@ -379,7 +379,7 @@ teams_rosters <-
           "idTeam",
           "yearSeason"
         ),
-        funs(. %>% as.character() %>%  readr::parse_number())
+        list(. %>% as.character() %>%  readr::parse_number())
       ) %>%
       tidyr::separate(schoolCoach, into = c("typeSchoolCoach", "nameSchoolCoach"), sep = "\\ - ") %>%
       suppressMessages() %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -342,9 +342,9 @@ get_data_classes <- function(data) {
       df_classes %>%
       left_join(df_nested_cols) %>%
       mutate_if(is_logical,
-                funs(ifelse(. %>% is.na(), FALSE, .))) %>%
+                list(ifelse(. %>% is.na(), FALSE, .))) %>%
       mutate_if(is_double,
-                funs(ifelse(. %>% is.na(), 0, .))) %>%
+                list(ifelse(. %>% is.na(), 0, .))) %>%
       suppressMessages()
   }
 
@@ -414,7 +414,7 @@ summarise_per_minute <-
       dplyr::select(-one_of(min_var)) %>%
       dplyr::select(one_of("minutes", id_columns), everything()) %>%
       mutate_at(munge_cols,
-                funs(. / minutes))
+                list(. / minutes))
 
     names(data) <-
       names(data) %>% str_replace_all("Totals|Advanced|PerGame|PerPossesion|Per36", "")
@@ -477,7 +477,7 @@ scale_per_minute <-
       data %>%
       dplyr::select(one_of("minutes"), everything()) %>%
       mutate_at(munge_cols,
-                funs(. / minutes))
+                list(. / minutes))
     if (!is_team) {
     names(data) <-
       names(data) %>% str_replace_all("Totals|Advanced|PerGame|PerPossesion|Per36", "")


### PR DESCRIPTION
Based on the warning:
```r
#> funs() is soft deprecated as of dplyr 0.8.0
#> please use list() instead
#> 
#> # Before:
#> funs(name = f(.)
#> 
#> # After: 
#> list(name = ~f(.))
```

replaces `funs()` with `list()` for scoped mutates